### PR TITLE
simpler to resolve

### DIFF
--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -1,7 +1,7 @@
 var http      = require('http'),
     https     = require('https'),
     url       = require('url'),
-    httpProxy = require('./http-proxy/');
+    httpProxy = require('./http-proxy/index');
 
 /**
  * Export the proxy "Server" as the main export.


### PR DESCRIPTION
Many packages use node-resolve to resolve dependencies asynchronously. Unfortunately, it's algo doesn't match require.resolve perfectly. It resolves `./http-proxy/` to `lib/http-proxy.js` instead of properly to `lib/http-proxy/index.js`
